### PR TITLE
Ajout de 14 codes USSD manquants (Orange, Free/Yas, Expresso)

### DIFF
--- a/data/ussd_codes_senegal.csv
+++ b/data/ussd_codes_senegal.csv
@@ -14,15 +14,29 @@ Orange,Sénégal,Achat Illimix,#250#,N/A,Acheter un Illimix (Jour/ Semaine/ Mois
 Orange,Sénégal,SOS Crédit,*770*montant_credit#,N/A,Service d'emprunt de credit (S.O.S credit ),Actif,2025-06-22
 Orange,Sénégal,Rappel moi,#120#,N/A,Service de rappel automatique,Actif,2025-09-28
 Orange,Sénégal,Services pratiques,#116#,N/A,Transfert de crédit et échange de bonus,Actif,2025-10-12
+Orange,Sénégal,Ouverture de compte Orange Money,#144#75#,N/A,Créer un compte Orange Money directement par USSD,Actif,2026-07-26
+Orange,Sénégal,Programme fidélité Orange Sargal,#221#,N/A,Inscription et suivi des points de fidélité (100F = 1 point),Actif,2026-07-26
+Orange,Sénégal,Orange Woma (notifications rappel),#321#,N/A,Activer/désactiver les notifications de rappel en cas de tentative d'appel sans crédit,Actif,2026-07-26
+Orange,Sénégal,Samay Niit,#444#,N/A,Appels gratuits vers numéros Orange/Kirène pendant une semaine,Actif,2026-07-26
+Orange,Sénégal,Allo S'cool,#205#,N/A,Minutes d'appel dédiées au programme Allo S'cool,Actif,2026-07-26
+Orange,Sénégal,Gestion des options et services,#145#,N/A,Menu opt-in/opt-out des abonnements,Actif,2026-07-26
+Orange,Sénégal,Consulter le coût et la durée du dernier appel émis,#123##,N/A,Affiche le coût et la durée du dernier appel émis,Actif,2025-05-11
 Free,Sénégal,Menu principal,#150#,N/A,Accès aux services Free Money,Actif,2025-05-09
 Free,Sénégal,Achat de crédit Free,#172#,N/A,Acheter du crédit Free,Actif,2025-05-09
 Free,Sénégal,Solde crédit Free,#176#,N/A,Vérifier le solde de votre crédit,Actif,2025-05-09
+Free,Sénégal,Solde principal (détaillé),#101#221#,N/A,Vérifier le solde principal via menu détaillé,Actif,2026-07-26
+Free,Sénégal,Solde bonus,#101#222#,N/A,Vérifier le solde bonus,Actif,2026-07-26
+Free,Sénégal,Solde internet/4G,#101#223#,N/A,Vérifier le solde des forfaits internet/4G,Actif,2026-07-26
+Free,Sénégal,Pass Internet journalier (Yas),#100#,N/A,Achat de pass internet journalier,Actif,2026-07-26
+Free,Sénégal,Achat Illimax (Yas),#155#,N/A,Achat de forfaits Illimax (Internet + Appels + SMS),Actif,2026-07-26
+Free,Sénégal,Forfaits internationaux/roaming (Yas),#155*5#,N/A,Souscription forfaits internationaux (CEDEAO, Maroc, Mauritanie, Gambie…),Actif,2026-07-26
+Free,Sénégal,Lebalma crédit (Yas),#188#,N/A,Emprunt de crédit d'urgence — remboursé à la prochaine recharge + frais,Actif,2026-07-26
 Wave,Sénégal,Menu principal (via Orange/Free),#2171#,N/A,Accès Wave via Orange / Free,Actif,2025-05-09
-Orange,Sénégal,Consulter le coût et la durée du dernier appel émis,#123##,N/A,Affiche le coût et la durée du dernier appel émis,Actif,2025-05-11
 Expresso,Sénégal,Solde crédit et Internet,*222#,N/A,Consulter le solde de crédit et internet,Actif,2025-05-11
 Expresso,Sénégal,Achat de pass Internet,*5#,N/A,Achat de forfaits Internet,Actif,2025-05-11
 Expresso,Sénégal,Portail expresso,*1111#,N/A,Portail un peu généraliste (Internet/ Programme de fidélité - teral/ Activer promo...),Actif,2025-05-11
 Expresso,Sénégal,Transfert de bonus,*9*montant*numero_beneficiaire*code_secret#,N/A,Transfére de bonus vers un autre numéro expresso,Actif,2025-05-11
+Expresso,Sénégal,Services internet mobile,*444#,N/A,Informations/services liés à l'internet mobile,Actif,2026-07-26
 Promobile,Sénégal,Solde de crédit,#123#,N/A,Consulter le solde de crédit,Actif,2025-06-22
 Promobile,Sénégal,Suivi consommation,#1175#,N/A,Suivre sa consommation de credit/ internet/ message,Actif,2025-06-22
 Promobile,Sénégal,Portail des offres,#175#,N/A,Acces à l'intégralité des offres mobile de Promobile,Actif,2025-06-22


### PR DESCRIPTION
## Résumé
Ajout de 14 codes USSD absents de la base actuelle, identifiés par recherche croisée sur des sources officielles (site Yas Sénégal, assistance Orange Sénégal) et communautaires (blogs télécom spécialisés Sénégal).

## Détail des ajouts
- **Orange (6 codes)** : ouverture de compte Orange Money (#144#75#), Orange Sargal (#221#), Orange Woma (#321#), Samay Niit (#444#), Allo S'cool (#205#), gestion des options (#145#)
- **Free / Yas (7 codes)** : soldes détaillés (#101#221#, #101#222#, #101#223#), pass internet (#100#), Illimax (#155#), forfaits internationaux (#155*5#), lebalma crédit (#188#)
- **Expresso (1 code)** : services internet mobile (*444#)

## Note importante
⚠️ Free Sénégal a été rebrandé **Yas** (site officiel : yas.sn). Je propose qu'on ouvre une issue séparée pour décider si on renomme l'opérateur `Free` → `Yas` dans tout le CSV ou si on garde `Free` avec une mention Yas en description, pour rester cohérent avec le marché actuel.

## Sources
- yas.sn (page officielle codes USSD, 2026)
- assistance.orange.sn (support officiel Orange Sénégal)
- Recoupement avec articles télécom Sénégal (JournalNT, GSIT)